### PR TITLE
📝 Updated link in README to not display '['

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FastAPI Model Server Skeleton
 
-Serving machine learning models production-ready, fast, easy and secure powered by the great FastAPI by [Sebastián Ramírez]([)](https://github.com/tiangolo).
+Serving machine learning models production-ready, fast, easy and secure powered by the great FastAPI by [Sebastián Ramírez](https://github.com/tiangolo).
 
 This repository contains a skeleton app which can be used to speed-up your next machine learning project. The code is fully tested and provides a preconfigured `tox` to quickly expand this sample code.
 


### PR DESCRIPTION
It appeared the link was meant to be the github user and not the repo itself.  I'm not sure the formatting you wanted, but I'm proposing fixing what I thought was a typo.

Cheers,
I like your skeleton 🎉; thanks for sharing ☺